### PR TITLE
Dual versions.

### DIFF
--- a/Shlongo.sln
+++ b/Shlongo.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shlongo.Aspire", "Shlongo.A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shlongo.Examples.Api", "Shlongo.Examples.Api\Shlongo.Examples.Api.csproj", "{2E066C86-6663-DB30-1983-E5A4E15F040C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shlongo3", "Shlongo3\Shlongo3.csproj", "{5EB579DE-F8FA-4EE7-6C43-20B34148F526}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shlongo2", "Shlongo2\Shlongo2.csproj", "{ABC98B85-8210-7B76-3649-2C73887E8C57}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +43,14 @@ Global
 		{2E066C86-6663-DB30-1983-E5A4E15F040C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E066C86-6663-DB30-1983-E5A4E15F040C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2E066C86-6663-DB30-1983-E5A4E15F040C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5EB579DE-F8FA-4EE7-6C43-20B34148F526}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5EB579DE-F8FA-4EE7-6C43-20B34148F526}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5EB579DE-F8FA-4EE7-6C43-20B34148F526}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5EB579DE-F8FA-4EE7-6C43-20B34148F526}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ABC98B85-8210-7B76-3649-2C73887E8C57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ABC98B85-8210-7B76-3649-2C73887E8C57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABC98B85-8210-7B76-3649-2C73887E8C57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ABC98B85-8210-7B76-3649-2C73887E8C57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Shlongo/Shlongo.csproj
+++ b/Shlongo/Shlongo.csproj
@@ -1,31 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<!-- Package Metadata -->
-		<PackageId>Shlongo</PackageId>
-		<Version>0.0.4-pre</Version>
-		<Authors>Affelios</Authors>
-		<Company>Affelios</Company>
-		<Product>Shlongo</Product>
-		<Description>A C# automated migration framework for MongoDB.</Description>
-		<PackageTags>mongodb;migrations;csharp;dotnet</PackageTags>
-		<PackageProjectUrl>https://github.com/Affelios/Shlongo</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/Affelios/Shlongo</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageReleaseNotes>Prerelease version.</PackageReleaseNotes>
-		<Copyright>© Affelios 2025</Copyright>
-
 		<!-- Build Settings -->
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-
-		<!-- Package Options -->
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Shlongo2/Shlongo2.csproj
+++ b/Shlongo2/Shlongo2.csproj
@@ -1,0 +1,58 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<!-- Package Metadata -->
+		<PackageId>Shlongo</PackageId>
+		<Version>2.28.0-pre</Version>
+		<Authors>Affelios</Authors>
+		<Company>Affelios</Company>
+		<Product>Shlongo</Product>
+		<Description>A C# automated migration framework for MongoDB.</Description>
+		<PackageTags>mongodb;migrations;csharp;dotnet</PackageTags>
+		<PackageProjectUrl>https://github.com/Affelios/Shlongo</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/Affelios/Shlongo</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageReleaseNotes>Prerelease version.</PackageReleaseNotes>
+		<Copyright>© Affelios 2025</Copyright>
+
+		<!-- Build Settings -->
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<!-- Package Options -->
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <Compile Include="..\Shlongo\IMongrationContext.cs" Link="IMongrationContext.cs" />
+	  <Compile Include="..\Shlongo\IServiceCollectionExtensions.cs" Link="IServiceCollectionExtensions.cs" />
+	  <Compile Include="..\Shlongo\MongoSession.cs" Link="MongoSession.cs" />
+	  <Compile Include="..\Shlongo\Mongration.cs" Link="Mongration.cs" />
+	  <Compile Include="..\Shlongo\MongrationContext.cs" Link="MongrationContext.cs" />
+	  <Compile Include="..\Shlongo\MongrationEngine.cs" Link="MongrationEngine.cs" />
+	  <Compile Include="..\Shlongo\MongrationOrchestrator.cs" Link="MongrationOrchestrator.cs" />
+	  <Compile Include="..\Shlongo\MongrationService.cs" Link="MongrationService.cs" />
+	  <Compile Include="..\Shlongo\MongrationState.cs" Link="MongrationState.cs" />
+	  <Compile Include="..\Shlongo\ShlongoConfiguration.cs" Link="ShlongoConfiguration.cs" />
+	  <Compile Include="..\Shlongo\ShlongoModule.cs" Link="ShlongoModule.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="../README.md" Pack="true" PackagePath="\" />
+		<None Include="../LICENSE" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+		<PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+	</ItemGroup>
+
+</Project>

--- a/Shlongo3/Shlongo3.csproj
+++ b/Shlongo3/Shlongo3.csproj
@@ -1,0 +1,58 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<!-- Package Metadata -->
+		<PackageId>Shlongo</PackageId>
+		<Version>3.4.0-pre</Version>
+		<Authors>Affelios</Authors>
+		<Company>Affelios</Company>
+		<Product>Shlongo</Product>
+		<Description>A C# automated migration framework for MongoDB.</Description>
+		<PackageTags>mongodb;migrations;csharp;dotnet</PackageTags>
+		<PackageProjectUrl>https://github.com/Affelios/Shlongo</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/Affelios/Shlongo</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageReleaseNotes>Prerelease version.</PackageReleaseNotes>
+		<Copyright>© Affelios 2025</Copyright>
+
+		<!-- Build Settings -->
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<!-- Package Options -->
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <Compile Include="..\Shlongo\IMongrationContext.cs" Link="IMongrationContext.cs" />
+	  <Compile Include="..\Shlongo\IServiceCollectionExtensions.cs" Link="IServiceCollectionExtensions.cs" />
+	  <Compile Include="..\Shlongo\MongoSession.cs" Link="MongoSession.cs" />
+	  <Compile Include="..\Shlongo\Mongration.cs" Link="Mongration.cs" />
+	  <Compile Include="..\Shlongo\MongrationContext.cs" Link="MongrationContext.cs" />
+	  <Compile Include="..\Shlongo\MongrationEngine.cs" Link="MongrationEngine.cs" />
+	  <Compile Include="..\Shlongo\MongrationOrchestrator.cs" Link="MongrationOrchestrator.cs" />
+	  <Compile Include="..\Shlongo\MongrationService.cs" Link="MongrationService.cs" />
+	  <Compile Include="..\Shlongo\MongrationState.cs" Link="MongrationState.cs" />
+	  <Compile Include="..\Shlongo\ShlongoConfiguration.cs" Link="ShlongoConfiguration.cs" />
+	  <Compile Include="..\Shlongo\ShlongoModule.cs" Link="ShlongoModule.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="../README.md" Pack="true" PackagePath="\" />
+		<None Include="../LICENSE" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+		<PackageReference Include="MongoDB.Driver" Version="3.4.0" />
+	</ItemGroup>
+
+</Project>


### PR DESCRIPTION
Two versions now in sync with two major Mongo library versions (2.x and 3.x).

Both generate and publish a nuget package.

Shlongo 2.28.0-pre maps to MongoDB.Driver 2.28.0
Shlongo 3.4.0-pre maps to MongoDB.Driver 3.4.0

We can now fix bugs in one place but release to libraries for now.