### PR TITLE
StartedAt and CompletedAt to mongration history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Shlongo is a lightweight, **unopinionated** framework to help manage **database 
 - Automatic discovery & execution of migrations in order  
 - Modular monolith friendly (able to process multiple independently numbered script collections in a single project)
 - Integration-friendly: works inside existing .NET / C# projects  
+- Migration history (`_mongrations`) records `StartedAt` and `CompletedAt` (plus legacy `ExecutedAt` for compatibility) so long-running or failed migrations keep a clear duration
 
 ---
 

--- a/Shlongo/MongrationEngine.cs
+++ b/Shlongo/MongrationEngine.cs
@@ -104,13 +104,15 @@ namespace Shlongo
         private async Task<MongrationState> RecordMongrationStartAsync(Mongration mongration, Guid batchId)
         {
             var collection = GetMongrationCollection();
+			var startedAt = DateTime.UtcNow;
 
 			var state = new MongrationState
 			{
 				MongrationId = mongration.Id,
 				MongrationName = mongration.Name,
                 MongrationNamespace = context.Configuration.Namespace,
-				ExecutedAt = DateTime.UtcNow,
+				StartedAt = startedAt,
+				ExecutedAt = startedAt,
 				BatchId = batchId
 			};
 
@@ -135,9 +137,11 @@ namespace Shlongo
                 Builders<MongrationState>.Filter.Eq(x => x.MongrationNamespace, context.Configuration.Namespace),
                 Builders<MongrationState>.Filter.Eq(x => x.MongrationId, mongrationId)
             );
+			var completedAt = DateTime.UtcNow;
 			var update = Builders<MongrationState>.Update
 				.Set(x => x.Status, MongrationStatus.Success)
-				.Set(x => x.ExecutedAt, DateTime.UtcNow);
+				.Set(x => x.CompletedAt, completedAt)
+				.Set(x => x.ExecutedAt, completedAt);
 			await GetMongrationCollection().UpdateOneAsync(filter, update);
 		}
 
@@ -147,9 +151,11 @@ namespace Shlongo
                 Builders<MongrationState>.Filter.Eq(x => x.MongrationNamespace, context.Configuration.Namespace),
                 Builders<MongrationState>.Filter.Eq(x => x.MongrationId, mongrationId)
             );
+			var completedAt = DateTime.UtcNow;
             var update = Builders<MongrationState>.Update
 				.Set(x => x.Status, MongrationStatus.Failure)
-				.Set(x => x.ExecutedAt, DateTime.UtcNow)
+				.Set(x => x.CompletedAt, completedAt)
+				.Set(x => x.ExecutedAt, completedAt)
 				.Set(x => x.Exception, ex.ToString());
 			await GetMongrationCollection().UpdateOneAsync(filter, update);
 		}

--- a/Shlongo/MongrationState.cs
+++ b/Shlongo/MongrationState.cs
@@ -22,6 +22,20 @@ namespace Shlongo
 
         public string MongrationName { get; set; } = string.Empty;
 
+        /// <summary>
+        /// When the mongration started (insert / Running).
+        /// </summary>
+        public DateTime StartedAt { get; set; }
+
+        /// <summary>
+        /// When the mongration finished (Success or Failure). Null while Running.
+        /// </summary>
+        public DateTime? CompletedAt { get; set; }
+
+        /// <summary>
+        /// Compatibility timestamp: equals <see cref="StartedAt"/> while Running,
+        /// and equals <see cref="CompletedAt"/> after Success or Failure.
+        /// </summary>
         public DateTime ExecutedAt { get; set; }
 
         [BsonRepresentation(BsonType.String)]

--- a/Shlongo2/Shlongo2.csproj
+++ b/Shlongo2/Shlongo2.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<!-- Package Metadata -->
 		<PackageId>Shlongo</PackageId>
-		<Version>2.28.4</Version>
+		<Version>2.29.0</Version>
 		<Authors>Affelios</Authors>
 		<Company>Affelios</Company>
 		<Product>Shlongo</Product>

--- a/Shlongo3/Shlongo3.csproj
+++ b/Shlongo3/Shlongo3.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<!-- Package Metadata -->
 		<PackageId>Shlongo</PackageId>
-		<Version>3.4.4</Version>
+		<Version>3.5.0</Version>
 		<Authors>Affelios</Authors>
 		<Company>Affelios</Company>
 		<Product>Shlongo</Product>


### PR DESCRIPTION
Preserve ExecutedAt as a compatibility field (start while Running, completion when terminal) so long-running and failed mongrations keep a recoverable duration.